### PR TITLE
Make clippy happy

### DIFF
--- a/languages/rust/oso/src/host/class.rs
+++ b/languages/rust/oso/src/host/class.rs
@@ -380,7 +380,7 @@ impl Instance {
     }
 
     pub(crate) fn debug_name(&self) -> &'static str {
-        &self.debug_type_name
+        self.debug_type_name
     }
 
     /// Lookup an attribute on the instance via the registered `Class`


### PR DESCRIPTION
Fixes the redundant reference which makes the upstream fail clippy checks.
